### PR TITLE
don't create local player on connect

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -98,9 +98,6 @@ public class GameManager : MonoBehaviour
 			else
 			{
 				GUILayout.Label($"Connected as client: {NetworkManager.Instance.ClientID}");
-
-				// Optionally, create or update the local player object
-				CreateOrUpdatePlayer(NetworkManager.Instance.ClientID, Vector2.zero); // Replace Vector2.zero with actual position
 			}
 
 			if (GUILayout.Button("Disconnect"))


### PR DESCRIPTION
removes client-side logic for instantiating the local player once connected since it will now happen on the server side as part of https://github.com/cbodonnell/flywheel/pull/5